### PR TITLE
upgrade external-resources-io

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds-proxy"
-version = "0.2.0"
+version = "0.2.1"
 description = "ERv2 module for managing AWS RDS Proxy clusters"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = "~= 3.12.0"
 dependencies = [
     "boto3==1.43.2",
-    "external-resources-io==0.6.3",
+    "external-resources-io==0.6.4",
     "pydantic==2.13.3",
 ]
 
@@ -20,7 +20,7 @@ documentation = "https://github.com/app-sre/er-aws-rds-proxy"
 [dependency-groups]
 dev = [
     "boto3-stubs-lite[ec2]==1.43.2",
-    "external-resources-io[cli]==0.6.3",
+    "external-resources-io[cli]==0.6.4",
     "mypy==1.20.2",
     "pytest-cov==7.1.0",
     "pytest-mock==3.15.1",

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds-proxy"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -147,14 +147,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = "==1.43.2" },
-    { name = "external-resources-io", specifier = "==0.6.3" },
+    { name = "external-resources-io", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.13.3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "boto3-stubs-lite", extras = ["ec2"], specifier = "==1.43.2" },
-    { name = "external-resources-io", extras = ["cli"], specifier = "==0.6.3" },
+    { name = "external-resources-io", extras = ["cli"], specifier = "==0.6.4" },
     { name = "mypy", specifier = "==1.20.2" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-cov", specifier = "==7.1.0" },
@@ -164,15 +164,15 @@ dev = [
 
 [[package]]
 name = "external-resources-io"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/96/452adb552b77f61e9c31ee1a907adfdad852ca25b950f2b66de74379c9c9/external_resources_io-0.6.3.tar.gz", hash = "sha256:625a2d63e808b618ab1063613923e9d9ea08bf9f0386d53f7942ca590318027b", size = 9120, upload-time = "2026-04-22T10:15:53.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/70/0dbfac5b451bc89bfaea010f3535ee825fbde3192ed3d8860fabaadb18cc/external_resources_io-0.6.4.tar.gz", hash = "sha256:a104cbc030dae3e0bccb2a876b7cced313368b1cda50f06ca0c278f1d2f318e6", size = 9108, upload-time = "2026-05-05T09:28:53.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/f1/90d545542903d2c0b4b03525da3d1df06a1828fec0e51277acf5a19bfec1/external_resources_io-0.6.3-py3-none-any.whl", hash = "sha256:dba2757ce7b50dbbad59afaa83c8962c3a9aa2397d74e2810db05fbb4c094d2a", size = 11803, upload-time = "2026-04-22T10:15:53.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/78/0afb24ca65a25e27efb6f9b6ec6cee79bd8c21e98a6ec8e8e0e8abb46a58/external_resources_io-0.6.4-py3-none-any.whl", hash = "sha256:55ff5f4fe5fbaa575b1d7a4267692d58518e4dab29192a1a27a8c52b8588f617", size = 11789, upload-time = "2026-05-05T09:28:52.166Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Upgrade `external-resources-io` and switch from `dynamodb_table` to `use_lockfile` (Terraform S3 backend)

Required by: https://github.com/app-sre/qontract-reconcile/pull/5525
Ticket: [APPSRE-13360](https://redhat.atlassian.net/browse/APPSRE-13360) 
